### PR TITLE
:bug: Ship compiled JavaScript in the published package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
+node_modules/
+dist/
+coverage/
+.nyc_output/
+*.log
+npm-debug.log*
+.DS_Store
 .idea/
 .vscode/
-lib/
-**/*.js
-node_modules/
-npm-debug.log
-dts/
-.nyc_output/
-dist/

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-docs/
-test/
-node_modules/
-.idea/
-tsconfig.json
-*.ts
-!dist/**/*.d.ts
-dist/**/*.js

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "URL related utilities.",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "mocha -r ts-node/register -r test/setup.ts --recursive test/**/*.test.ts",
     "cov": "nyc npm test",
@@ -11,7 +14,7 @@
     "fix": "tslint --fix --project ./",
     "compile": "tsc",
     "build": "rm -rf dist && mkdir dist && tsc --noEmit false",
-    "prepare": "tsc",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run lint && npm run cov && npm run build"
   },
   "repository": {


### PR DESCRIPTION
## The bug

`@tselect/url@1.0.0` on npm contains **no JavaScript**. It has never worked at runtime.

`.npmignore` line 8 read `dist/**/*.js`. Every sibling repo has `!dist/**/*.js` — the negation that *re-includes* compiled output after the blanket ignore rules. The missing `!` turned it into an exclusion.

Verified against the real registry tarball, not a local dry-run:

```
npm pack @tselect/url@1.0.0   →  8 .d.ts files, 0 .js files
require('@tselect/url')       →  Error: Cannot find module '.../dist/index.js'
```

Blast radius is `url` alone — `status-code` and `http-method` tarballs ship JS correctly.

A second, independent break: `prepare: "tsc"` emitted nothing, because `tsconfig.json` sets `noEmit: true`. Only `prepublishOnly`'s `npm run build` (which overrides with `--noEmit false`) ever compiled, so `npm pack` from a clean checkout produced an empty `dist/`.

## Changes

- Delete `.npmignore`, replace with an explicit `"files": ["dist"]` allowlist. Also stops publishing `.nyc_output/` (which leaked absolute local filesystem paths) and `tslint.json`.
- `prepare: "tsc"` → `"npm run build"` so a clean checkout compiles. Stopgap — tsup removes this script entirely in a later PR.
- `.gitignore`: drop `**/*.js`, which would silently swallow flat config files like `eslint.config.js` and make a future lint job pass vacuously. Also drops dead `lib/` and `dts/` entries; adds `coverage/`, `*.log`, `.DS_Store`.
- Remove `.idea/` and `.nyc_output/` from the working tree.

## Verification

Packed from a clean checkout (no `node_modules`, no `dist`, so `prepare` had to build from nothing), installed the resulting tarball into a scratch consumer, and required it.

| | Before | After |
| --- | --- | --- |
| Tarball | 16 files | 18 files |
| JavaScript | **0** | 8 |
| `.nyc_output/` | 5 files published | gone |
| `require()` | throws | 7 exports |

Exports match the 1.0.0 baseline exactly: `HTTP_PROTOCOL_REG`, `PROTOCOL_REG`, `ensureHTTPProtocol`, `ensureLeadingSlash`, `ensureSlashes`, `ensureTrailingSlash`, `join`. Behaviour smoke test returns `foo/`, `http://example.com`, `a/b/c`. Tests: 23 passing, unchanged.

**No source files touched.**

First of 7 stacked PRs modernizing this package. Nothing here publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)