### PR TITLE
:construction_worker: Run CI from the org-wide reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# Thin caller for the org-wide reusable workflow in `tselect-npm/.github`.
+# Every input has a default suited to this toolchain (pnpm + tsdown + Vitest +
+# Biome + tsc), so there is nothing to configure here.
+#
+# The `@v1` pin is deliberate and must never become `@main`: an edit upstream
+# would otherwise change all seven repos' CI on their next run with no review in
+# any of them. `v1` moves for fixes and backwards-compatible additions; anything
+# that could turn a passing build red gets `v2` and repos migrate one at a time.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Set here rather than in the reusable workflow: inside a reusable workflow
+# `github.workflow` and `github.ref` resolve to the caller's, so every repo
+# calling it would share one concurrency group and cancel each other.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  ci:
+    uses: tselect-npm/.github/.github/workflows/ci.yml@v1

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 [![npm](https://img.shields.io/npm/v/@tselect/url.svg?style=flat-square)](https://www.npmjs.com/package/@tselect/url)
 [![npm](https://img.shields.io/npm/dm/@tselect/url.svg?style=flat-square)](https://www.npmjs.com/package/@tselect/url)
+[![CI](https://img.shields.io/github/actions/workflow/status/tselect-npm/url/ci.yml?branch=main&style=flat-square)](https://github.com/tselect-npm/url/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/coverallsCoverage/github/tselect-npm/url?branch=main&style=flat-square)](https://coveralls.io/github/tselect-npm/url?branch=main)
 [![license](https://img.shields.io/npm/l/@tselect/url.svg?style=flat-square)](./LICENSE)
 
 URL related utilities.
 
-Zero runtime dependencies. Ships both ESM and CommonJS builds, with TypeScript types for each.
+Zero runtime dependencies. Ships both ESM and CommonJS builds, with TypeScript types for each. Tested on Node 22, 24 and 26.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 
 URL related utilities.
 
-Zero runtime dependencies. Ships both ESM and CommonJS builds, with TypeScript types for each. Tested on Node 22, 24 and 26.
+Zero runtime dependencies. Ships both ESM and CommonJS builds, with TypeScript types for each.
+
+## Requirements
+
+**Node 22 or newer** (`engines.node` is `>=22`) — every line still receiving security support. Each release is tested on 22, 24 and 26; the declared floor is the lowest version CI actually runs, not a guess.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
   },
   "author": "Sylvain Estevez",
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "packageManager": "pnpm@11.21.0",
   "bugs": {
     "url": "https://github.com/tselect-npm/url/issues"


### PR DESCRIPTION
Targets `chore/modernize` (#19), not `main`.

Wires `url` into the reusable workflow in `tselect-npm/.github`, and declares the Node floor. **CI green on all seven jobs**, Coveralls uploading.

## The caller

Three lines of YAML — every input already defaults to this toolchain.

| Job | What runs |
| --- | --- |
| `test (node 22/24/26)` | `pnpm cov` on every supported line; coverage thresholds are the gate |
| `typecheck + lint` | `tsc --noEmit` and `biome check .` (Biome covers formatting too) |
| `build + package` | build, then assert JS **and** declarations exist, `es-check es2015`, pack for real and read the tarball, `attw` on it |
| `audit` | `pnpm audit --audit-level low`, blocking |
| `ci` | aggregate — the one stable name to require in branch protection |

- **`@v1`, never `@main`.** Central logic is leverage in both directions; an edit upstream would change all seven repos with no review in any of them. (`v1`/`v1.0.0` didn't exist — I tagged them at da37be9, without which the pin fails to resolve.)
- **`concurrency` lives here**, not upstream: inside a reusable workflow `github.workflow` and `github.ref` resolve to the *caller's*, so all seven repos would share one group and cancel each other.
- CI + coverage badges, held out of #19 because they'd have rendered broken until this workflow existed.

## `engines.node` is `">=22"`

The rule that produced it: **the floor is the bottom of the test matrix.** Same number, not a number chosen alongside it — so it's proven by construction, with no extra job and nothing to keep in sync. `engines` is enforced (pnpm hard-fails an install below the floor), so it's a promise, and a promise nobody runs is a comment.

`">=20"` was the first choice and isn't viable — not for policy reasons:

```
$ node --version   # v20.16.0
$ pnpm install --frozen-lockfile
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

pnpm 11.21.0 declares `"node": ">=22.13"` and dies before a single test runs; `tsdown` wants `^22.18.0 || >=24.11.0`. A Node 20 row would need an npm fallback — per-repo special-casing in the one repo built to prevent it. Since `>=20` and `>=22` both break someone and both cost a major, the tie goes to the provable one. Node 20 hit EOL 2026-04-30.

**This raises the floor, so `url` releases as a major (2.0.0).** It supersedes the additive support policy's floor half — that policy assumed a wide floor was free, and it isn't: an undeclared floor isn't a *wider* promise, just an untested one. The ceiling half stands, and `es-check-target: es2015` still holds emitted syntax where it was. The shipped code isn't what forces the floor; the toolchain is.

## Verification

[Run 31402353714](https://github.com/tselect-npm/url/actions/runs/31402353714):

```
success  ci / test (node 22)   success  ci / build + package
success  ci / test (node 24)   success  ci / audit
success  ci / test (node 26)   success  ci / ci
success  ci / typecheck + lint
```

Coveralls uploaded cleanly ([job 185966366](https://coveralls.io/jobs/185966366)) — the one path the CI session couldn't exercise itself.

Companion doc PR: tselect-npm/.github#5.