### PR TITLE
PROBE — do not merge: verify the smoke matrix on Node 14/16/18/20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,6 @@ concurrency:
 
 jobs:
   ci:
-    uses: tselect-npm/.github/.github/workflows/ci.yml@v1
+    uses: tselect-npm/.github/.github/workflows/ci.yml@feat/smoke-node-matrix
+    with:
+      smoke-node-versions: '["14.0.0", "14", "16", "18", "20"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# Thin caller for the org-wide reusable workflow in `tselect-npm/.github`.
+# Every input has a default suited to this toolchain (pnpm + tsdown + Vitest +
+# Biome + tsc), so there is nothing to configure here.
+#
+# The `@v1` pin is deliberate and must never become `@main`: an edit upstream
+# would otherwise change all seven repos' CI on their next run with no review in
+# any of them. `v1` moves for fixes and backwards-compatible additions; anything
+# that could turn a passing build red gets `v2` and repos migrate one at a time.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Set here rather than in the reusable workflow: inside a reusable workflow
+# `github.workflow` and `github.ref` resolve to the caller's, so every repo
+# calling it would share one concurrency group and cancel each other.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  ci:
+    uses: tselect-npm/.github/.github/workflows/ci.yml@v1

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 [![npm](https://img.shields.io/npm/v/@tselect/url.svg?style=flat-square)](https://www.npmjs.com/package/@tselect/url)
 [![npm](https://img.shields.io/npm/dm/@tselect/url.svg?style=flat-square)](https://www.npmjs.com/package/@tselect/url)
+[![CI](https://img.shields.io/github/actions/workflow/status/tselect-npm/url/ci.yml?branch=main&style=flat-square)](https://github.com/tselect-npm/url/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/coverallsCoverage/github/tselect-npm/url?branch=main&style=flat-square)](https://coveralls.io/github/tselect-npm/url?branch=main)
 [![license](https://img.shields.io/npm/l/@tselect/url.svg?style=flat-square)](./LICENSE)
 
 URL related utilities.
 
-Zero runtime dependencies. Ships both ESM and CommonJS builds, with TypeScript types for each.
+Zero runtime dependencies. Ships both ESM and CommonJS builds, with TypeScript types for each. Tested on Node 22, 24 and 26.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
   },
   "author": "Sylvain Estevez",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "packageManager": "pnpm@11.21.0",
   "bugs": {
     "url": "https://github.com/tselect-npm/url/issues"


### PR DESCRIPTION
Throwaway. Pins the reusable workflow at `@feat/smoke-node-matrix` to find out whether `actions/setup-node` can actually provision Node 14.0.0 / 14 / 16 / 18 / 20 on `ubuntu-24.04`, and whether the packed tarball loads there. Deleted once answered.