### PR TITLE
:construction_worker: DO NOT MERGE — probe run for the TypeScript CI refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ concurrency:
 
 jobs:
   ci:
-    uses: tselect-npm/.github/.github/workflows/ci.yml@v1
+    uses: tselect-npm/.github/.github/workflows/ci.yml@v1-test


### PR DESCRIPTION
Temporary probe. Points this repo's caller at `tselect-npm/.github@v1-test` so the new TypeScript job wrapper actually runs on a runner before `v1` moves.

Validates what a PR against `.github` structurally cannot: `github.action_path` resolution, the composite `outputs.result` plumbing, and every job going through `actions/run-ci-script`.

Closed and deleted once `v1` moves. See tselect-npm/.github#6.