### PR TITLE
:construction_worker: Add the release caller workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+# Thin caller for the org-wide reusable release workflow in `tselect-npm/.github`.
+# Publishing happens here and nowhere else — there is no npm token on anyone's
+# laptop once trusted publishing is configured for this package.
+#
+# **This file must stay named `publish.yml`.** npm's trusted publisher config for
+# `@tselect/url` names one workflow file, and for a reusable workflow npm
+# validates the *caller's* filename rather than the reusable one. Renaming this
+# file breaks publishing with a 404 that mentions nothing about filenames.
+#
+# The `@v1` pin is deliberate and must never become `@main`, for the same reason
+# as ci.yml: an edit upstream would otherwise change every repo's release
+# behaviour with no review in any of them.
+
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump. `auto` reads it from the gitmoji since the last release.'
+        type: choice
+        options: [auto, patch, minor, major]
+        default: auto
+      dry-run:
+        description: 'Plan, rehearse the publish, then stop before anything is pushed or published.'
+        type: boolean
+        default: false
+      dist-tag:
+        description: 'npm dist-tag.'
+        type: string
+        default: latest
+      since-ref:
+        description: >-
+          Count commits from this ref instead of the tag matching the published
+          version. Needed for the first @tselect release: the tag named after the
+          published 1.0.0 is @bluejay's, so the range otherwise reaches back into
+          a lineage that has nothing to do with this package.
+        type: string
+        default: ''
+
+# A release must never be cancelled by a later one: the tag is pushed before
+# `pnpm publish` runs, so an interruption in that window leaves a tagged version
+# the registry does not have. Re-running recovers it, but not being interrupted
+# is better. Note this differs from ci.yml, where cancelling is the point.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    permissions:
+      # Push the release commit and the tag to `main`.
+      contents: write
+      # Mint the OIDC token npm exchanges for publish rights. Required *here* as
+      # well as in the reusable workflow: a called workflow can only narrow the
+      # permissions it is given, so omitting this produces a job with no token
+      # and a 404 from the registry.
+      id-token: write
+    uses: tselect-npm/.github/.github/workflows/publish.yml@v1
+    with:
+      bump: ${{ inputs.bump }}
+      dry-run: ${{ inputs.dry-run }}
+      dist-tag: ${{ inputs.dist-tag }}
+      since-ref: ${{ inputs.since-ref }}


### PR DESCRIPTION
Publishing moves to CI. **Actions → Publish → Run workflow**, with the bump read out of the gitmoji since the last release and an approval required from the `npm-publish` environment's shortlist before anything is pushed or published.

Calls [`tselect-npm/.github`'s `publish.yml`](https://github.com/tselect-npm/.github/pull/9), pinned `@v1`.

## Two load-bearing details

- **The filename must stay `publish.yml`** — npm's trusted publisher validates the *caller's* workflow filename, not the reusable one it delegates to.
- **`id-token: write` is granted here as well as upstream** — a called workflow can only narrow the permissions it is given, so omitting it produces a job with no OIDC token.

Both fail as a bare `404` from the registry that names neither cause.

`cancel-in-progress: false`, unlike `ci.yml`: the tag is pushed before the publish, so cancelling in that window is the one interruption the design cannot make cheap.

## Tags were cleaned up first (already pushed)

The `@bluejay`-era tags occupied the versions the `@tselect` line was walking back into — `v2.0.0` was taken, which is exactly what this package's modernization major wants. The registry records the commit each version shipped from, so the fix was a lookup rather than a guess:

```console
$ npm view @tselect/url@1.0.0 gitHead
de093bb54ecba3a0c84d31badd26654708631454   # :sparkles: Cleanup and migrate to tselect
```

Seven obsolete tags removed, `v1.0.0` created at `de093bb`. Recovery record — every commit is still reachable from `main`, so any of these can be recreated exactly:

| Tag | Commit | Subject |
| --- | --- | --- |
| `v3.0.0-beta.2` | `21793d8` | `:bookmark: 3.0.0-beta.2` |
| `v3.0.0-beta.1` | `f73d108` | `:bookmark: 3.0.0-beta.1` |
| `v3.0.0-beta.0` | `7d24019` | `:bookmark: 3.0.0-beta.0` |
| `v2.0.1` | `9a3a40a` | `:bookmark: 2.0.1` |
| `v2.0.0` | `b2466e8` | `:bookmark: 2.0.0` |
| `v1.1.0` | `75d78bf` | `:bookmark: 1.0.1` ⚠️ mislabelled |
| `1.0.0` | `1f6ab90` | `:books: Added documentation` ⚠️ mislabelled |

The last two were already inconsistent with their own commits. With `v1.0.0` now naming the commit the published `1.0.0` actually shipped from, the planner resolves on the first try — the commit range went from 24 commits reaching into a foreign lineage to the 9 that are the modernization.

## Verified locally

```
Counting commits since v1.0.0, the tag for the published version.
9 commit(s) since v1.0.0
Overriding the inferred minor with major.
@tselect/url: 1.0.0 → 2.0.0 (major, chosen explicitly (gitmoji implied minor))
```

The `major` override is required and not incidental: `:wrench: Declare engines.node >=22` infers as *no release*, and no gitmoji marks a raised runtime floor as breaking.

## Not usable until

`tselect-npm/.github` #9 merges and `v1` moves. First run should be `dry-run: true` — it still requires the approval and still runs `prepublishOnly` and the pack, but stops before the commit, tag, push and publish.